### PR TITLE
Always open the document in editable mode

### DIFF
--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -457,7 +457,9 @@ class MetashapeWorkflow:
 
         # Load the project
         self.doc = Metashape.Document()
-        self.doc.open(project_file)
+        # Note that this will always open the project in editable mode, even if it's currently open
+        # elsewhere or or the previous run did not shut down properly.
+        self.doc.open(project_file, ignore_lock=True)
 
         # Set up instance variables (same as project_setup)
         self.project_name = project_name


### PR DESCRIPTION
If the project is opened read-only, it will fail after wasting compute when the corresponding step tries to save. A read-only state can happen if the previous run failed and you are "retrying' in Argo or if the document is opened in the Metashape GUI. I think the automate-metashape run should always supersede the existing lock. But I'd be curious if there are any cases where this might not be the case?

This change just ignores the lock when the project is opened. Closes #105, which just suggested an immediate failure rather than fixing the issue.