### PR TITLE
Export model and pointcloud in local frame if no reference is provided

### DIFF
--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -1472,14 +1472,26 @@ class MetashapeWorkflow:
                 self.cfg["project"]["output_path"],
                 self.project_name + export_file_ending,
             )
+            # Get the CRS to export in
+            export_CRS = self.get_export_CRS()
+
             if self.cfg["build_point_cloud"]["classes"] == "ALL":
+                # The COPC format requires a valid CRS, not the "LOCAL" option
+                # The comparison operator is not implemented so the wkt string must be used. This
+                # works for the local CRS as well.
+                export_format = (
+                    self.cfg["build_point_cloud"]["export_format"]
+                    if export_CRS.wkt != Metashape.CoordinateSystem("LOCAL").wkt
+                    else Metashape.PointCloudFormatLAZ
+                )
+
                 # call without classes argument (Metashape then defaults to all classes)
                 with self.benchmark.monitor("exportPointCloud"):
                     self.doc.chunk.exportPointCloud(
                         path=output_file,
                         source_data=Metashape.PointCloudData,
-                        format=self.cfg["build_point_cloud"]["export_format"],
-                        crs=self.get_export_CRS(),
+                        crs=export_CRS,
+                        format=export_format,
                         subdivide_task=self.cfg["project"]["subdivide_task"],
                     )
                 self.written_paths["point_cloud_all_classes"] = output_file  # export
@@ -1490,7 +1502,7 @@ class MetashapeWorkflow:
                         path=output_file,
                         source_data=Metashape.PointCloudData,
                         format=Metashape.PointCloudFormatLAZ,
-                        crs=self.get_export_CRS(),
+                        crs=export_CRS,
                         classes=self.cfg["build_point_cloud"]["classes"],
                         subdivide_task=self.cfg["project"]["subdivide_task"],
                     )

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -548,6 +548,25 @@ class MetashapeWorkflow:
 
         self.doc.save()
 
+    def get_export_CRS(self):
+        """
+        If the model is georeferenced, return the "project" -> "project_crs" from the config.
+        Otherwise, return the local CRS. This avoids errors trying to transform to the project CRS
+        when the model is not georeferenced.
+
+        Note, this could cause problems if GCPs were used, as this would still return the local CRS.
+        But GCPs are not currently used in practice.
+        """
+        # Check if any cameras have a reference location
+        if any(
+            [camera.reference.location is not None for camera in self.doc.chunk.cameras]
+        ):
+            # Return the project CRS
+            return Metashape.CoordinateSystem(self.cfg["project"]["project_crs"])
+
+        # Otherwise, return the specifier for the local (unitless) coordinate system
+        return Metashape.CoordinateSystem("LOCAL")
+
     def match_photos(self):
         """
         Match photos step: Find tie points between photos.
@@ -1460,9 +1479,7 @@ class MetashapeWorkflow:
                         path=output_file,
                         source_data=Metashape.PointCloudData,
                         format=self.cfg["build_point_cloud"]["export_format"],
-                        crs=Metashape.CoordinateSystem(
-                            self.cfg["project"]["project_crs"]
-                        ),
+                        crs=self.get_export_CRS(),
                         subdivide_task=self.cfg["project"]["subdivide_task"],
                     )
                 self.written_paths["point_cloud_all_classes"] = output_file  # export
@@ -1473,9 +1490,7 @@ class MetashapeWorkflow:
                         path=output_file,
                         source_data=Metashape.PointCloudData,
                         format=Metashape.PointCloudFormatLAZ,
-                        crs=Metashape.CoordinateSystem(
-                            self.cfg["project"]["project_crs"]
-                        ),
+                        crs=self.get_export_CRS(),
                         classes=self.cfg["build_point_cloud"]["classes"],
                         subdivide_task=self.cfg["project"]["subdivide_task"],
                     )
@@ -1528,7 +1543,7 @@ class MetashapeWorkflow:
             with self.benchmark.monitor("exportModel"):
                 self.doc.chunk.exportModel(
                     path=output_file,
-                    crs=Metashape.CoordinateSystem(self.cfg["project"]["project_crs"]),
+                    crs=self.get_export_CRS(),
                     save_metadata_xml=True,
                     shift=shift,
                 )


### PR DESCRIPTION
Closes #106.

Previously, there would be an issue if the model or point cloud was exported in a real CRS but no georeferencing information was provided by way of the image locations. This checks to see if no images have a location and if so exports in the local coordinate system. Note, the local export option does not produce a metadata file.